### PR TITLE
Add indent for ctor function

### DIFF
--- a/pkg/typgen/context.go
+++ b/pkg/typgen/context.go
@@ -42,7 +42,7 @@ func (i *Context) AppendInitf(format string, args ...interface{}) {
 
 func (i *Context) ProvideConstructor(name, importPath, constructor string) {
 	alias := i.InitAliasGen.Generate(importPath)
-	s := fmt.Sprintf(`typapp.Provide("%s", %s.%s)`, name, alias, constructor)
+	s := fmt.Sprintf("\ttypapp.Provide(\"%s\", %s.%s)", name, alias, constructor)
 	i.AppendInit(s)
 }
 


### PR DESCRIPTION
This will format the generation code as follows
```go
func init(){
	typapp.Provide("", a.NewEcho)

}
```

instead of
```go
func init(){
typapp.Provide("", a.NewEcho)
}
```