### PR TITLE
Remove bou.ke/monkey dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/typical-go/typical-go
 go 1.17
 
 require (
-	bou.ke/monkey v1.0.2
 	github.com/bmatcuk/doublestar/v2 v2.0.4
 	github.com/fatih/color v1.9.0
 	github.com/golang/mock v1.4.4

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-bou.ke/monkey v1.0.2 h1:kWcnsrCNUatbxncxR/ThdYqbytgOIArtYWqcQLQzKLI=
-bou.ke/monkey v1.0.2/go.mod h1:OqickVX3tNx6t33n1xvtTtu85YN5s6cKwVug+oHMaIA=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/bmatcuk/doublestar/v2 v2.0.4 h1:6I6oUiT/sU27eE2OFcWqBhL1SwjyvQuOssxT4a1yidI=

--- a/pkg/filekit/filepath.go
+++ b/pkg/filekit/filepath.go
@@ -19,7 +19,7 @@ func MatchMulti(patterns []string, name string) bool {
 
 // FindDir find directory
 func FindDir(includes, excludes []string) (packages []string, err error) {
-	err = filepath.Walk(".", func(path string, info os.FileInfo, err error) error {
+	err = filepath.WalkDir(".", func(path string, info os.DirEntry, err error) error {
 		if MatchMulti(includes, path) && !MatchMulti(excludes, path) && info.IsDir() {
 			packages = append(packages, "./"+path)
 		}

--- a/pkg/typgo/gotest_test.go
+++ b/pkg/typgo/gotest_test.go
@@ -36,7 +36,7 @@ func setupGoTest(t *testing.T) func(t *testing.T) {
 	return func(t *testing.T) {
 		os.RemoveAll("pkg1")
 		os.RemoveAll("pkg2")
-		os.RemoveAll("pkg")
+		os.RemoveAll("pkg_mock")
 	}
 }
 


### PR DESCRIPTION
You mostly can't monkey patch the way you can in dynamic languages. This usually leads to overcomplicating the test, limitations, and possible errors. For example, in the current implementation, a subtle logical error was made, leading to the fact that the test always passed. And in general this is not Go-way. To do the same sort of thing, the idiomatic way in Go is to have interfaces that you switch out. This is basically just dependency injection. However, it seems that in these two particular cases it was enough to apply the setUp/tearDown pattern.

In addition, `filepath.Walk` in `filekit.filepath.FindDir` was replaced by `filepath.WalkDir` due to `Walk` is less efficient than `WalkDir`, introduced in Go 1.16

Fixes #6